### PR TITLE
Change build order in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ install:
   - cd cortoproject
   - git clone https://github.com/cortoproject/corto.git
   - git clone https://github.com/cortoproject/c-binding.git
+  - git clone https://github.com/cortoproject/json.git
   - git clone https://github.com/cortoproject/xml.git
   - git clone https://github.com/cortoproject/corto-language.git
   - git clone https://github.com/cortoproject/io.git
   - git clone https://github.com/cortoproject/cortodoc.git
   - git clone https://github.com/cortoproject/test.git
-  - git clone https://github.com/cortoproject/json.git
   - |+
-    echo 'COMPONENTS = %w(corto c-binding xml corto-language io cortodoc test json web)
+    echo 'COMPONENTS = %w(corto c-binding json xml corto-language io cortodoc test web)
     require "#{ENV["CORTO_BUILD"]}/forward"' > rakefile
   - for g in $(find . -name .git); do echo -e "$(basename $(dirname $g))\t$(git --git-dir $g rev-parse HEAD)"; done | column -t
   - source corto/configure


### PR DESCRIPTION
Build was failing because corto/test did not build correctly. And the latter, because corto/json was built before test, which is now the wrong order since json is required for project.json and test is now built with project.json